### PR TITLE
Use waiter defined in SDK

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "boto3>=1.10.20",
-        "botocore>=1.13.20",
         "Jinja2>=2.10",
         "jsonschema>=3.0.1",
         "pytest==4.5.0",

--- a/src/rpdk/core/__init__.py
+++ b/src/rpdk/core/__init__.py
@@ -1,5 +1,5 @@
 import logging
 
-__version__ = "0.1"
+__version__ = "0.1.1"
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/rpdk/core/__init__.py
+++ b/src/rpdk/core/__init__.py
@@ -1,5 +1,5 @@
 import logging
 
-__version__ = "0.1.1"
+__version__ = "0.1"
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -6,7 +6,6 @@ from tempfile import TemporaryFile
 from uuid import uuid4
 
 from botocore.exceptions import ClientError, WaiterError
-from botocore.waiter import WaiterModel, create_waiter_with_client
 from jinja2 import Environment, PackageLoader, select_autoescape
 from jsonschema import Draft6Validator
 from jsonschema.exceptions import ValidationError
@@ -336,37 +335,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
 
     @staticmethod
     def _wait_for_registration(cfn_client, registration_token, set_default):
-        # temporarily creating waiter inline
-        # until the SDK releases and we can use get_waiter
-        waiter_config = {
-            "version": 2,
-            "waiters": {
-                "TypeRegistrationComplete": {
-                    "delay": 5,
-                    "operation": "DescribeTypeRegistration",
-                    "maxAttempts": 200,
-                    "description": "Wait until type registration is COMPLETE.",
-                    "acceptors": [
-                        {
-                            "argument": "ProgressStatus",
-                            "expected": "COMPLETE",
-                            "matcher": "path",
-                            "state": "success",
-                        },
-                        {
-                            "argument": "ProgressStatus",
-                            "expected": "FAILED",
-                            "matcher": "path",
-                            "state": "failure",
-                        },
-                    ],
-                }
-            },
-        }
-        registration_waiter = create_waiter_with_client(
-            "TypeRegistrationComplete", WaiterModel(waiter_config), cfn_client
-        )
-        # registration_waiter = cfn_client.get_waiter("TypeRegistrationComplete")
+        registration_waiter = cfn_client.get_waiter("TypeRegistrationComplete")
         try:
             LOG.warning(
                 "Successfully submitted type. "

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -335,7 +335,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
 
     @staticmethod
     def _wait_for_registration(cfn_client, registration_token, set_default):
-        registration_waiter = cfn_client.get_waiter("TypeRegistrationComplete")
+        registration_waiter = cfn_client.get_waiter("type_registration_complete")
         try:
             LOG.warning(
                 "Successfully submitted type. "

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -565,19 +565,15 @@ def test__upload_clienterror(project):
 
 def test__wait_for_registration_set_default(project):
     mock_cfn_client = MagicMock(
-        spec=["describe_type_registration", "set_type_default_version"]
+        spec=["describe_type_registration", "set_type_default_version", "get_waiter"]
     )
     mock_cfn_client.describe_type_registration.return_value = (
         DESCRIBE_TYPE_COMPLETE_RETURN
     )
     mock_waiter = MagicMock(spec=["wait"])
-    patch_create_waiter = patch(
-        "rpdk.core.project.create_waiter_with_client",
-        autospec=True,
-        return_value=mock_waiter,
-    )
-    with patch_create_waiter:
-        project._wait_for_registration(mock_cfn_client, REGISTRATION_TOKEN, True)
+    mock_cfn_client.get_waiter.return_value = mock_waiter
+
+    project._wait_for_registration(mock_cfn_client, REGISTRATION_TOKEN, True)
 
     mock_cfn_client.describe_type_registration.assert_called_once_with(
         RegistrationToken=REGISTRATION_TOKEN
@@ -590,7 +586,7 @@ def test__wait_for_registration_set_default(project):
 
 def test__wait_for_registration_set_default_fails(project):
     mock_cfn_client = MagicMock(
-        spec=["describe_type_registration", "set_type_default_version"]
+        spec=["describe_type_registration", "set_type_default_version", "get_waiter"]
     )
     mock_cfn_client.describe_type_registration.return_value = (
         DESCRIBE_TYPE_COMPLETE_RETURN
@@ -599,12 +595,9 @@ def test__wait_for_registration_set_default_fails(project):
         BLANK_CLIENT_ERROR, "SetTypeDefaultVersion"
     )
     mock_waiter = MagicMock(spec=["wait"])
-    patch_create_waiter = patch(
-        "rpdk.core.project.create_waiter_with_client",
-        autospec=True,
-        return_value=mock_waiter,
-    )
-    with patch_create_waiter, pytest.raises(DownstreamError):
+    mock_cfn_client.get_waiter.return_value = mock_waiter
+
+    with pytest.raises(DownstreamError):
         project._wait_for_registration(mock_cfn_client, REGISTRATION_TOKEN, True)
 
     mock_cfn_client.describe_type_registration.assert_called_once_with(
@@ -618,19 +611,15 @@ def test__wait_for_registration_set_default_fails(project):
 
 def test__wait_for_registration_no_set_default(project):
     mock_cfn_client = MagicMock(
-        spec=["describe_type_registration", "set_type_default_version"]
+        spec=["describe_type_registration", "set_type_default_version", "get_waiter"]
     )
     mock_cfn_client.describe_type_registration.return_value = (
         DESCRIBE_TYPE_COMPLETE_RETURN
     )
     mock_waiter = MagicMock(spec=["wait"])
-    patch_create_waiter = patch(
-        "rpdk.core.project.create_waiter_with_client",
-        autospec=True,
-        return_value=mock_waiter,
-    )
-    with patch_create_waiter:
-        project._wait_for_registration(mock_cfn_client, REGISTRATION_TOKEN, False)
+    mock_cfn_client.get_waiter.return_value = mock_waiter
+
+    project._wait_for_registration(mock_cfn_client, REGISTRATION_TOKEN, False)
 
     mock_cfn_client.describe_type_registration.assert_called_once_with(
         RegistrationToken=REGISTRATION_TOKEN
@@ -641,7 +630,7 @@ def test__wait_for_registration_no_set_default(project):
 
 def test__wait_for_registration_waiter_fails(project):
     mock_cfn_client = MagicMock(
-        spec=["describe_type_registration", "set_type_default_version"]
+        spec=["describe_type_registration", "set_type_default_version", "get_waiter"]
     )
     mock_cfn_client.describe_type_registration.return_value = (
         DESCRIBE_TYPE_FAILED_RETURN
@@ -652,11 +641,9 @@ def test__wait_for_registration_waiter_fails(project):
         "Waiter encountered a terminal failure state",
         DESCRIBE_TYPE_FAILED_RETURN,
     )
+    mock_cfn_client.get_waiter.return_value = mock_waiter
 
-    patch_create_waiter = patch(
-        "rpdk.core.project.create_waiter_with_client", return_value=mock_waiter
-    )
-    with patch_create_waiter, pytest.raises(DownstreamError):
+    with pytest.raises(DownstreamError):
         project._wait_for_registration(mock_cfn_client, REGISTRATION_TOKEN, True)
 
     mock_cfn_client.describe_type_registration.assert_called_once_with(
@@ -668,7 +655,7 @@ def test__wait_for_registration_waiter_fails(project):
 
 def test__wait_for_registration_waiter_fails_describe_fails(project):
     mock_cfn_client = MagicMock(
-        spec=["describe_type_registration", "set_type_default_version"]
+        spec=["describe_type_registration", "set_type_default_version", "get_waiter"]
     )
     mock_cfn_client.describe_type_registration.side_effect = ClientError(
         BLANK_CLIENT_ERROR, "DescribeTypeRegistration"
@@ -680,10 +667,9 @@ def test__wait_for_registration_waiter_fails_describe_fails(project):
         DESCRIBE_TYPE_FAILED_RETURN,
     )
 
-    patch_create_waiter = patch(
-        "rpdk.core.project.create_waiter_with_client", return_value=mock_waiter
-    )
-    with patch_create_waiter, pytest.raises(DownstreamError):
+    mock_cfn_client.get_waiter.return_value = mock_waiter
+
+    with pytest.raises(DownstreamError):
         project._wait_for_registration(mock_cfn_client, REGISTRATION_TOKEN, False)
 
     mock_cfn_client.describe_type_registration.assert_called_once_with(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Just realized that to get a waiter, you have to use snake case for the waiter name instead of camel case. Tested locally.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
