### PR TITLE
fixing GovCloud arn partition

### DIFF
--- a/examples/schema/aws.common.types.v1.json
+++ b/examples/schema/aws.common.types.v1.json
@@ -4,7 +4,7 @@
     "definitions": {
         "Arn": {
             "type": "string",
-            "pattern": "^arn:aws(-(cn|gov))?:[a-z-]+:(([a-z]+-)+[0-9])?:([0-9]{12})?:[^.]+$"
+            "pattern": "^arn:aws(-(cn|us-gov))?:[a-z-]+:(([a-z]+-)+[0-9])?:([0-9]{12})?:[^.]+$"
         },
         "Tags": {
             "type": "array",


### PR DESCRIPTION
https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/using-govcloud-arns.html

We should also consider something more general like:

`arn:aws(-[a-z-]*)?:`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.